### PR TITLE
Vite compatability: Add .vue extension

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import FocusPoint from './components/FocusPoint'
+import FocusPoint from './components/FocusPoint.vue'
 
 export default FocusPoint


### PR DESCRIPTION
As mentioned in a closed issue: https://github.com/EvodiaAut/vue-focuspoint-component/issues/9